### PR TITLE
Fix tests failing with expected errors in `tape_reset_test_debug.sh`

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ on your tape drive.
 Example:
 
 ```
-  dnf install -y git, lsscsi, mt-st, sg3_utils
+  sudo dnf install -y git lsscsi mt-st sg3_utils
   git clone https://github.com/johnmeneghini/tape_tests.git
   cd tape_tests
   sudo ./run_tests.sh /dev/nst0 /dev/sg1 0 0 0 6 1

--- a/tape_reset_lib.sh
+++ b/tape_reset_lib.sh
@@ -10,7 +10,7 @@ DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 counter=1
 
 stop_on_pos_err() {
-	echo "--- position_lost_in_reset TEST FAILED--- with status $1"
+	echo -e "\033[31m--- position_lost_in_reset TEST FAILED--- with status $1\033[0m"
 	if [[ "$STOERR" -eq 1 ]]; then
 		echo "Exiting"
 		exit 1
@@ -19,7 +19,7 @@ stop_on_pos_err() {
 
 stop_on_cmd_err() {
 	cmd_err="$(cat .cmd_err)"
-	echo "--- $1 TEST FAILED : $cmd_err"
+	echo -e "\033[31m--- $1 TEST FAILED : $cmd_err\033[0m"
 	if [[ "$STOERR" -eq 1 ]]; then
 		echo "Exiting"
 		exit 1;
@@ -27,7 +27,7 @@ stop_on_cmd_err() {
 }
 
 stop_on_err() {
-	echo "--- $1 TEST FAILED --- with status $2"
+	echo -e "\033[31m--- $1 TEST FAILED --- with status $2\033[0m"
 	if [[ "$STOERR" -eq 1 ]]; then
 		echo "Exiting"
 		exit 1;
@@ -51,8 +51,8 @@ do_cmd_warn() {
 	$1 2> .cmd_err || err=$?
 	cat .cmd_err
 	cmd_err="$(cat .cmd_err)"
-	grep -E "failed|error" .cmd_err > /dev/null 2>&1 && echo "--- $1 TEST WARN : $cmd_err"
-	if [[ $err -ne 0 ]]; then echo "--- $1 TEST WARN : returned status $err"; fi
+	grep -E "failed|error" .cmd_err > /dev/null 2>&1 && echo -e "\033[33m--- $1 TEST WARN : $cmd_err\033[0m"
+	if [[ $err -ne 0 ]]; then echo -e "\033[33m--- $1 TEST WARN : returned status $err\033[0m" ; fi
 	rm -f .cmd_err
 	((counter++))
 }

--- a/tape_reset_test_debug.sh
+++ b/tape_reset_test_debug.sh
@@ -174,20 +174,25 @@ for i in $(seq $h $j); do
     do_cmd_false "dd if=/dev/random count=50 of=$TAPE$i "
     do_cmd_false "mt -f $TAPE$i weof 1 "
     test_reset_blocked_true "nst$i"
-	do_cmd_true "mt -f $TAPE$i status"
-	do_cmd_warn "mt -f $TAPE$i tell"
+    do_cmd_true "mt -f $TAPE$i status"
+    do_cmd_false "mt -f $TAPE$i tell"
+done
+
+echo " Rewind the tape"
+for i in $(seq $h $j); do
+   do_cmd_true "mt -f $TAPE$i rewind"
 done
 
 echo " Try reading the tape"
 for i in $(seq $h $j); do
-    do_cmd_false "dd if=$TAPE$i count=50 of=/dev/null"
-    test_reset_blocked_true "nst$i"
+    do_cmd_true "dd if=$TAPE$i count=50 of=/dev/null"
+    test_reset_blocked_false "nst$i"
 done
 
 echo " Check the status"
 for i in $(seq $h $j); do
     do_cmd_true " mt -f $TAPE$i status"
-	do_cmd_warn "mt -f $TAPE$i tell"
+    do_cmd_warn "mt -f $TAPE$i tell"
 done
 
 echo " Load the tape"


### PR DESCRIPTION
Some of the commands in `tape_reset_test_debug.sh`  are expected to fail and should not be considered test failures.
After a SCSI target reset, the tape drive enters the `UNIT ATTENTION` state. The `st` driver causes almost all requests to fail with `EIO`, except for a few that are able to clear this sense key. With `rewind` being one of them, this command was added into the test script after the reset to make sure the sense key is cleared and the drive is ready for more tests.